### PR TITLE
Fix setup script not working on Windows | 修复在Windows系统上无法运行setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ if os.path.exists(output_path):
     print("Delete temporary files")
     shutil.rmtree(output_path)
 
-r = os.system("idf.py > /dev/null")
+r = os.system("idf.py > " + os.devnull)
 if r != 0:
     print(
         "Unable to execute idf.py, please see here to learn how to use and install https://github.com/espressif/esp-idf"


### PR DESCRIPTION
The main reason `setup.py` does not work on windows is because of `/dev/null` is not a valid path on windows, on windows its `NUL`. This patch fixed the problem by replacing the hardcoded path with `os.devnull`.

初次构建脚本 `setup.py` 无法正常在 Windows 上运行的主要原因是 `/dev/null` 并不存在于 Windows系统, 此路径在 Windows 系统上等效于 `NUL`. 这个 PR 使用 `os.devnull` 字符串替代了硬编码字符串中的路径来修复了问题.

![image](https://github.com/Xinyuan-LilyGO/LilyGo-Display-IDF/assets/8848056/545da5a3-ee5b-4004-a5fa-9760f889d4ff)
