### PR TITLE
Fix missing defination for CONFIG_LILYGO_T_DISPLAY_S3_AMOLED | 修复 AMOLED-S3 无法正常编译

### DIFF
--- a/main/amoled_driver.c
+++ b/main/amoled_driver.c
@@ -16,6 +16,7 @@
 #include <string.h>
 
 #if defined(CONFIG_LILYGO_T_AMOLED_LITE_147) || \
+    defined(CONFIG_LILYGO_T_DISPLAY_S3_AMOLED) || \
     defined(CONFIG_LILYGO_T_DISPLAY_S3_AMOLED_TOUCH) || \
     defined(CONFIG_LILYGO_T4_S3_241)
 


### PR DESCRIPTION
Added ifdef for `CONFIG_LILYGO_T_DISPLAY_S3_AMOLED`, or the repo would not compile when `LILYGO_T_DISPLAY_S3_AMOLED` is selected.

在 `main/amoled_drivers.c` 缺少了对 `CONFIG_LILYGO_T_DISPLAY_S3_AMOLED` 的检测, 导致了编译时提示 ```undefined reference to `display_init'```. 此 PR 添加了缺少的定义, 添加后即可正常编译.

以下是修改前的编译日志

```text
...[Omitted/省略]
[5/7] Linking CXX executable lilygo_display_project.elf
FAILED: lilygo_display_project.elf
cmd.exe /C "cd . && %USERPROFILE%\.espressif\tools\xtensa-esp-elf\esp-13.2.0_20230928\xtensa-esp-elf\bin\xtensa-esp32s3-elf-g++.exe -mlongcalls -Wl,--cref -Wl,--defsym=IDF_TARGET_ESP32S3=0 -Wl,--Map=%PROJECT_PATH%/build/lilygo_display_project.map -Wl,--no-warn-rwx-segments -fno-rtti -fno-lto -Wl,--gc-sections -Wl,--warn-common -T esp32s3.peripherals.ld -T esp32s3.rom.ld -T esp32s3.rom.api.ld -T esp32s3.rom.libgcc.ld -T esp32s3.rom.newlib.ld -T esp32s3.rom.version.ld -T memory.ld -T sections.ld @CMakeFiles\lilygo_display_project.elf.rsp -o lilygo_display_project.elf  && cd ."
%USERPROFILE%/.espressif/tools/xtensa-esp-elf/esp-13.2.0_20230928/xtensa-esp-elf/bin/../lib/gcc/xtensa-esp-elf/13.2.0/../../../../xtensa-esp-elf/bin/ld.exe: esp-idf/main/libmain.a(main.cpp.obj):(.literal._ZL21example_lvgl_flush_cbP14_lv_disp_drv_tPK9lv_area_tP12lv_color16_t+0x0): undefined reference to `display_push_colors'
%USERPROFILE%/.espressif/tools/xtensa-esp-elf/esp-13.2.0_20230928/xtensa-esp-elf/bin/../lib/gcc/xtensa-esp-elf/13.2.0/../../../../xtensa-esp-elf/bin/ld.exe: esp-idf/main/libmain.a(main.cpp.obj):(.literal.app_main+0x68): undefined reference to `display_init'
%USERPROFILE%/.espressif/tools/xtensa-esp-elf/esp-13.2.0_20230928/xtensa-esp-elf/bin/../lib/gcc/xtensa-esp-elf/13.2.0/../../../../xtensa-esp-elf/bin/ld.exe: esp-idf/main/libmain.a(main.cpp.obj): in function `example_lvgl_flush_cb(_lv_disp_drv_t*, lv_area_t const*, lv_color16_t*)':
%PROJECT_PATH%/main/main.cpp:54:(.text._ZL21example_lvgl_flush_cbP14_lv_disp_drv_tPK9lv_area_tP12lv_color16_t+0x2d): undefined reference to `display_push_colors'
%USERPROFILE%/.espressif/tools/xtensa-esp-elf/esp-13.2.0_20230928/xtensa-esp-elf/bin/../lib/gcc/xtensa-esp-elf/13.2.0/../../../../xtensa-esp-elf/bin/ld.exe: esp-idf/main/libmain.a(main.cpp.obj): in function `app_main':
%PROJECT_PATH%/main/main.cpp:142:(.text.app_main+0x87): undefined reference to `display_init'
collect2.exe: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
ninja failed with exit code 1, output of the command is in the%PROJECT_PATH%\build\log\idf_py_stderr_output_50272 and %PROJECT_PATH%\build\log\idf_py_stdout_output_50272
```